### PR TITLE
Add SubexpNames & Expand

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,69 @@
+package gonigmo
+
+import (
+	"fmt"
+)
+
+func ExampleRegexp_Expand() {
+	content := []byte(`
+	# comment line
+	option1: value1
+	option2: value2
+
+	# another comment line
+	option3: value3
+`)
+
+	// Regex pattern captures "key: value" pair from the content.
+	pattern := MustCompile(`(?m)(?<key>\w+):\s+(?<value>\w+)$`)
+
+	// Template to convert "key: value" to "key=value" by
+	// referencing the values captured by the regex pattern.
+	template := []byte("$key=$value\n")
+
+	result := []byte{}
+
+	// For each match of the regex in the content.
+	for _, submatches := range pattern.FindAllSubmatchIndex(content, -1) {
+		// Apply the captured submatches to the template and append the output
+		// to the result.
+		result = pattern.Expand(result, template, content, submatches)
+	}
+	fmt.Println(string(result))
+	// Output:
+	// option1=value1
+	// option2=value2
+	// option3=value3
+}
+
+func ExampleRegexp_ExpandString() {
+	content := `
+	# comment line
+	option1: value1
+	option2: value2
+
+	# another comment line
+	option3: value3
+`
+
+	// Regex pattern captures "key: value" pair from the content.
+	pattern := MustCompile(`(?m)(?<key>\w+):\s+(?<value>\w+)$`)
+
+	// Template to convert "key: value" to "key=value" by
+	// referencing the values captured by the regex pattern.
+	template := "$key=$value\n"
+
+	result := []byte{}
+
+	// For each match of the regex in the content.
+	for _, submatches := range pattern.FindAllStringSubmatchIndex(content, -1) {
+		// Apply the captured submatches to the template and append the output
+		// to the result.
+		result = pattern.ExpandString(result, template, content, submatches)
+	}
+	fmt.Println(string(result))
+	// Output:
+	// option1=value1
+	// option2=value2
+	// option3=value3
+}

--- a/regex.go
+++ b/regex.go
@@ -13,7 +13,9 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"sync"
+	"unicode"
 	"unicode/utf8"
 	"unsafe"
 )
@@ -45,6 +47,7 @@ type Regexp struct {
 	errorBuf       *C.char
 	matchData      *matchData
 	namedGroupInfo namedGroupInfo
+	subexpNames    map[int]string
 	mutex          *sync.Mutex
 }
 
@@ -68,6 +71,11 @@ func NewRegexp(pattern string, option int) (re *Regexp, err error) {
 			re.matchData.indices[i] = make([]int32, numCapturesInPattern*2)
 		}
 		re.namedGroupInfo = re.getNamedGroupInfo()
+		re.subexpNames = make(map[int]string, len(re.namedGroupInfo))
+		for name, i := range re.namedGroupInfo {
+			re.subexpNames[i] = name
+		}
+		//eventually not works, we need do it manually
 		//runtime.SetFinalizer(re, (*Regexp).Free)
 	}
 	return re, err
@@ -216,6 +224,12 @@ func (re *Regexp) Free() {
 	}
 }
 
+// SubexpNames returns the names of the parenthesized subexpressions
+// in this Regexp.
+func (re *Regexp) SubexpNames() map[int]string {
+	return re.subexpNames
+}
+
 func (re *Regexp) getNamedGroupInfo() (namedGroupInfo namedGroupInfo) {
 	numNamedGroups := int(C.onig_number_of_names(re.regex))
 	//when any named capture exisits, there is no numbered capture even if there are unnamed captures
@@ -302,6 +316,121 @@ func (re *Regexp) find(b []byte, n int, offset int) (match []int) {
 		}
 	}
 	return match
+}
+
+// Expand appends template to dst and returns the result; during the
+// append, Expand replaces variables in the template with corresponding
+// matches drawn from src. The match slice should have been returned by
+// FindSubmatchIndex.
+func (re *Regexp) Expand(dst []byte, template []byte, src []byte, match []int) []byte {
+	return re.expand(dst, string(template), src, "", match)
+}
+
+// ExpandString is like Expand but the template and source are strings.
+// It appends to and returns a byte slice in order to give the calling
+// code control over allocation.
+func (re *Regexp) ExpandString(dst []byte, template string, src string, match []int) []byte {
+	return re.expand(dst, template, nil, src, match)
+}
+
+func (re *Regexp) expand(dst []byte, template string, bsrc []byte, src string, match []int) []byte {
+	for len(template) > 0 {
+		i := strings.Index(template, "$")
+		if i < 0 {
+			break
+		}
+		dst = append(dst, template[:i]...)
+		template = template[i:]
+		if len(template) > 1 && template[1] == '$' {
+			// Treat $$ as $.
+			dst = append(dst, '$')
+			template = template[2:]
+			continue
+		}
+		name, num, rest, ok := extractTemplate(template)
+		if !ok {
+			// Malformed; treat $ as raw text.
+			dst = append(dst, '$')
+			template = template[1:]
+			continue
+		}
+		template = rest
+		if num >= 0 {
+			if 2*num+1 < len(match) && match[2*num] >= 0 {
+				if bsrc != nil {
+					dst = append(dst, bsrc[match[2*num]:match[2*num+1]]...)
+				} else {
+					dst = append(dst, src[match[2*num]:match[2*num+1]]...)
+				}
+			}
+		} else {
+			for i, namei := range re.subexpNames {
+				if name == namei && 2*i+1 < len(match) && match[2*i] >= 0 {
+					if bsrc != nil {
+						dst = append(dst, bsrc[match[2*i]:match[2*i+1]]...)
+					} else {
+						dst = append(dst, src[match[2*i]:match[2*i+1]]...)
+					}
+					break
+				}
+			}
+		}
+	}
+	dst = append(dst, template...)
+	return dst
+}
+
+// extractTemplate returns the name from a leading "$name" or "${name}" in str.
+// If it is a number, extract returns num set to that number; otherwise num = -1.
+func extractTemplate(str string) (name string, num int, rest string, ok bool) {
+	if len(str) < 2 || str[0] != '$' {
+		return
+	}
+	brace := false
+	if str[1] == '{' {
+		brace = true
+		str = str[2:]
+	} else {
+		str = str[1:]
+	}
+	i := 0
+	for i < len(str) {
+		rune, size := utf8.DecodeRuneInString(str[i:])
+		if !unicode.IsLetter(rune) && !unicode.IsDigit(rune) && rune != '_' {
+			break
+		}
+		i += size
+	}
+	if i == 0 {
+		// empty name is not okay
+		return
+	}
+	name = str[:i]
+	if brace {
+		if i >= len(str) || str[i] != '}' {
+			// missing closing brace
+			return
+		}
+		i++
+	}
+
+	// Parse number.
+	num = 0
+	for i := 0; i < len(name); i++ {
+		if name[i] < '0' || '9' < name[i] || num >= 1e8 {
+			num = -1
+			break
+		}
+		num = num*10 + int(name[i]) - '0'
+	}
+	// Disallow leading zeros.
+	if name[0] == '0' && len(name) > 1 {
+		num = -1
+	}
+
+	rest = str[i:]
+	ok = true
+	return
 }
 
 func extract(b []byte, beg int, end int) []byte {


### PR DESCRIPTION
`SubexpNames` is slightly different with `regexp.SubexpNames`, but can be used in the same form:

`for i, name := range re.SubexpNames()`